### PR TITLE
Python implementation of med_dml

### DIFF
--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -1074,7 +1074,9 @@ def med_dml(
         ptx[i] = res.predict_proba(x[test])[:, 1]
 
         # predict P(T=1|M,X)
-        res = LogisticRegressionCV(random_state=random_state, Cs=cs, cv=CV_FOLDS).fit(
+        res = LogisticRegressionCV(
+            random_state=random_state, Cs=cs, cv=CV_FOLDS
+            ).fit(xm[train], t[train])
             xm[train], t[train]
         )
         ptmx[i] = res.predict_proba(xm[test])[:, 1]

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -956,22 +956,30 @@ def med_dml(
     ----------
     x : array-like, shape (n_samples, n_features_covariates)
         Covariates value for each unit, multidimensional or continuous.
+
     t : array-like, shape (n_samples)
         Treatment value for each unit.
+
     m : array-like, shape (n_samples, n_features_mediator)
         Mediator value for each unit, multidimensional or continuous.
+
     y : array-like, shape (n_samples)
         Outcome value for each unit.
+
     crossfit : int, default=0
         Number of folds for cross-fitting.
+
     trim : float, default=0.05
         Trimming treshold for discarding observations with extreme probability.
+
     normalized : boolean, default=True
         Normalizes the inverse probability-based weights.
+
     regularization : boolean, default=True
         Whether to use regularized models (logistic or linear regression).
         If True, cross-validation is used to chose among 8 potential
         log-spaced values between 1e-5 and 1e5.
+
     random_state : int, default=None
         LogisticRegression random state instance.
 
@@ -983,7 +991,7 @@ def med_dml(
         Direct effect on the exposed.
     direct0 : float
         Direct effect on the unexposed,
-    indirect1 : float 
+    indirect1 : float
         Indirect effect on the exposed.
     indirect0 : float
         Indirect effect on the unexposed.
@@ -1038,6 +1046,7 @@ def med_dml(
     var_name += ["mu_t1_m_x", "mu_t0_m_x", "w_t0_x", "w_t1_x", "mu_t1_x", "mu_t0_x"]
     nobs = 0
 
+    # define regularization parameters
     if regularization:
         alphas = ALPHAS
         cs = ALPHAS
@@ -1159,11 +1168,11 @@ def med_dml(
     my0m1 = np.mean([np.mean(_) for _ in y0m1])
 
     # effects computing
-    total = my1m1 - my0m0  # total effect
-    direct1 = my1m1 - my0m1  # theta1
-    direct0 = my1m0 - my0m0  # theta0
-    indirect1 = my1m1 - my1m0  # delta1
-    indirect0 = my0m1 - my0m0  # delta0
+    total = my1m1 - my0m0
+    direct1 = my1m1 - my0m1
+    direct0 = my1m0 - my0m0
+    indirect1 = my1m1 - my1m0
+    indirect0 = my0m1 - my0m0
     return total, direct1, direct0, indirect1, indirect0, n - nobs
 
 

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -1056,8 +1056,18 @@ def med_dml(
         mu_t0_x,  # E[Y|T=0,X]
     ) = [np.empty((max(crossfit, 1),), dtype=object) for _ in range(12)]
 
-    var_name = ["tte", "yte", "ptx", "ptmx"]
-    var_name += ["mu_t1_m_x", "mu_t0_m_x", "w_t0_x", "w_t1_x", "mu_t1_x", "mu_t0_x"]
+    var_name = [
+        "tte",
+        "yte",
+        "ptx",
+        "ptmx",
+        "mu_t1_m_x",
+        "mu_t0_m_x",
+        "w_t0_x",
+        "w_t1_x",
+        "mu_t1_x",
+        "mu_t0_x",
+    ]
     nobs = 0
 
     # define regularization parameters

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -1068,17 +1068,13 @@ def med_dml(
         yte[i] = y[test]
 
         # predict P(T=1|X)
-        res = LogisticRegressionCV(
-            random_state=random_state,
-            Cs=cs,
-            cv=CV_FOLDS,
-        ).fit(x[train], t[train])
+        res = LogisticRegressionCV(random_state=random_state, Cs=cs, cv=CV_FOLDS).fit(
+            x[train], t[train]
+        )
         ptx[i] = res.predict_proba(x[test])[:, 1]
 
         # predict P(T=1|M,X)
-        res = LogisticRegressionCV(
-            random_state=random_state, Cs=cs, cv=CV_FOLDS
-            ).fit(xm[train], t[train])
+        res = LogisticRegressionCV(random_state=random_state, Cs=cs, cv=CV_FOLDS).fit(
             xm[train], t[train]
         )
         ptmx[i] = res.predict_proba(xm[test])[:, 1]

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -9,7 +9,7 @@ causal inference, simulate data, and evaluate and compare estimators
 import rpy2.robjects as robjects
 import rpy2.robjects.packages as rpackages
 from rpy2.robjects import pandas2ri, numpy2ri
-from sklearn.linear_model import Lasso, LogisticRegression, LogisticRegressionCV, LinearRegression, RidgeCV
+from sklearn.linear_model import LogisticRegressionCV, RidgeCV, LassoCV
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.preprocessing import PolynomialFeatures
 from sklearn.calibration import CalibratedClassifierCV
@@ -935,7 +935,17 @@ def medDML(y, t, m, x, trim=0.05, order=1):
     return list(raw_res_R[0, :5]) + [ntrimmed]
 
 
-def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
+def med_dml(
+    x,
+    t,
+    m,
+    y,
+    crossfit=0,
+    trim=0.05,
+    normalized=True,
+    regularization=True,
+    random_state=None,
+):
     """
     Python implementation of Double Machine Learning procedure, as described in :
     Helmut Farbmacher and others, Causal mediation analysis with double machine learning,
@@ -954,14 +964,18 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
         Can be multidimensional or continuous
     y : array-like, shape (n_samples)
         Outcome value for each unit
-    k : int, default=4
-        Number of folds for crossfitting.
+    crossfit : int, default=0
+        Number of folds for cross-fitting.
     trim : float, default=0.05
         Trimming treshold for discarding observations with extreme probability.
     normalized : boolean, default=True
         Normalizes the inverse probability-based weights.
-    alpha : float, default=10**-4
-        Lasso penalization for conditinal means estimation.
+    regularization : boolean, default=True
+        Whether to use regularized models (logistic or linear regression).
+        If True, cross-validation is used to chose among 8 potential
+        log-spaced values between 1e-5 and 1e5.
+    random_state : int, default=None
+        LogisticRegression random state instance.
 
     Returns
     -------
@@ -1022,6 +1036,13 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
     var_name += ["mu_t1_m_x", "mu_t0_m_x", "w_t0_x", "w_t1_x", "mu_t1_x", "mu_t0_x"]
     nobs = 0
 
+    if regularization:
+        alphas = ALPHAS
+        cs = ALPHAS
+    else:
+        alphas = [0.0]
+        cs = [np.inf]
+
     # define cross-fitting folds
     if crossfit < 2:
         train_test_list = [(np.arange(n), np.arange(n))]
@@ -1045,45 +1066,47 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
         yte[i] = y[test]
 
         # predict P(T=1|X)
-        res = LogisticRegression(penalty="l1", solver="liblinear").fit(
-            x[train], t[train]
-        )
+        res = LogisticRegressionCV(
+            random_state=random_state,
+            Cs=cs,
+            cv=CV_FOLDS,
+        ).fit(x[train], t[train])
         ptx[i] = res.predict_proba(x[test])[:, 1]
 
         # predict P(T=1|M,X)
-        res = LogisticRegression(penalty="l1", solver="liblinear").fit(
+        res = LogisticRegressionCV(random_state=random_state, Cs=cs, cv=CV_FOLDS).fit(
             xm[train], t[train]
         )
         ptmx[i] = res.predict_proba(xm[test])[:, 1]
 
         # predict E[Y|T=1,M,X]
-        res = Lasso(alpha).fit(xm[train_mean1], y[train_mean1])
+        res = LassoCV(alphas=alphas, cv=CV_FOLDS).fit(xm[train_mean1], y[train_mean1])
         mu_t1_m_x[i] = res.predict(xm[test])
         mu_t1_m_x_nested[i] = res.predict(xm[train_nested])
 
         # predict E[Y|T=0,M,X]
-        res = Lasso(alpha).fit(xm[train_mean0], y[train_mean0])
+        res = LassoCV(alphas=alphas, cv=CV_FOLDS).fit(xm[train_mean0], y[train_mean0])
         mu_t0_m_x[i] = res.predict(xm[test])
         mu_t0_m_x_nested[i] = res.predict(xm[train_nested])
 
         # predict E[E[Y|T=1,M,X]|T=0,X]
-        res = Lasso(alpha).fit(
+        res = LassoCV(alphas=alphas, cv=CV_FOLDS).fit(
             x[train_nested0], mu_t1_m_x_nested[i][t[train_nested] == 0]
         )
         w_t0_x[i] = res.predict(x[test])
 
         # predict E[E[Y|T=0,M,X]|T=1,X]
-        res = Lasso(alpha).fit(
+        res = LassoCV(alphas=alphas, cv=CV_FOLDS).fit(
             x[train_nested1], mu_t0_m_x_nested[i][t[train_nested] == 1]
         )
         w_t1_x[i] = res.predict(x[test])
 
         # predict E[Y|T=1,X]
-        res = Lasso(alpha).fit(x[train1], y[train1])
+        res = LassoCV(alphas=alphas, cv=CV_FOLDS).fit(x[train1], y[train1])
         mu_t1_x[i] = res.predict(x[test])
 
         # predict E[Y|T=0,X]
-        res = Lasso(alpha).fit(x[train0], y[train0])
+        res = LassoCV(alphas=alphas, cv=CV_FOLDS).fit(x[train0], y[train0])
         mu_t0_x[i] = res.predict(x[test])
 
         # trimming

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -1016,19 +1016,22 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
         w_t1_x,  # E[E[Y|T=0,M,X]|T=1,X]
         mu_t1_x,  # E[Y|T=1,X]
         mu_t0_x,  # E[Y|T=0,X]
-    ) = [np.empty((k,), dtype=object) for _ in range(12)]
+    ) = [np.empty((max(crossfit, 1),), dtype=object) for _ in range(12)]
 
     var_name = ["tte", "yte", "ptx", "ptmx"]
     var_name += ["mu_t1_m_x", "mu_t0_m_x", "w_t0_x", "w_t1_x", "mu_t1_x", "mu_t0_x"]
     nobs = 0
 
     # define cross-fitting folds
-    kf = KFold(n_splits=k)
-    train_test_list = list(kf.split(x))
+    if crossfit < 2:
+        train_test_list = [(np.arange(n), np.arange(n))]
+    else:
+        kf = KFold(n_splits=crossfit)
+        train_test_list = list(kf.split(x))
 
-    for i in range(0, k):
+    for i, train_test in enumerate(train_test_list):
         # define test set
-        train, test = train_test_list[i]
+        train, test = train_test
         train1 = train[t[train] == 1]
         train0 = train[t[train] == 0]
 

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -956,7 +956,7 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
         Outcome value for each unit
     k : int, default=4
         Number of folds for crossfitting.
-    trim : double, default=0.05
+    trim : float, default=0.05
         Trimming treshold for discarding observations with extreme probability.
     normalized : boolean, default=True
         Normalizes the inverse probability-based weights.
@@ -965,14 +965,14 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
 
     Returns
     -------
-    list
-        A list of estimated effects :
-        [total effect,
+    tuple
+        A tuple of estimated effects :
+        (total effect,
         direct effect on the exposed,
         direct effect on the unexposed,
         indirect effect on the exposed,
         indirect effect on the unexposed,
-        number of discarded samples]
+        number of discarded samples)
 
     Raises
     ------
@@ -1146,9 +1146,9 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
     # vindirect1 = np.mean(np.mean((y1m1 - y1m0 - indirect1) ** 2))
     # vindirect0 = np.mean(np.mean((y0m1 - y0m0 - indirect0) ** 2))
 
-    # var = [vtotal, vdirect1, vdirect0, vindirect1, vindirect0]
+    # var = vtotal, vdirect1, vdirect0, vindirect1, vindirect0
 
-    return [total, direct1, direct0, indirect1, indirect0, n - nobs]
+    return total, direct1, direct0, indirect1, indirect0, n - nobs
 
 
 def _convert_array_to_R(x):

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -1168,16 +1168,6 @@ def med_dml(
     direct0 = my1m0 - my0m0  # theta0
     indirect1 = my1m1 - my1m0  # delta1
     indirect0 = my0m1 - my0m0  # delta0
-
-    # # variance computing
-    # vtotal = np.mean(np.mean((y1m1 - y0m0 - total) ** 2))
-    # vdirect1 = np.mean(np.mean((y1m1 - y0m1 - direct1) ** 2))
-    # vdirect0 = np.mean(np.mean((y1m0 - y0m0 - direct0) ** 2))
-    # vindirect1 = np.mean(np.mean((y1m1 - y1m0 - indirect1) ** 2))
-    # vindirect0 = np.mean(np.mean((y0m1 - y0m0 - indirect0) ** 2))
-
-    # var = vtotal, vdirect1, vdirect0, vindirect1, vindirect0
-
     return total, direct1, direct0, indirect1, indirect0, n - nobs
 
 

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -946,8 +946,7 @@ def med_dml(
     normalized=True,
     regularization=True,
     random_state=None,
-    calibration=True,
-    calib_method="sigmoid",
+    calib_method=None,
 ):
     """
     Python implementation of Double Machine Learning procedure, as described in :
@@ -991,14 +990,11 @@ def med_dml(
     random_state : int, default=None
         LogisticRegression random state instance.
 
-    calibration : boolean, default=True
-        Whether to add a calibration step so that the classifier used to estimate
-        the treatment propensity score and P(T|M,X).
+    calib_method : {None, "sigmoid", "isotonic"}, default=None
+        Whether to add a calibration step for the classifier used to estimate
+        the treatment propensity score and P(T|M,X). "None" means no calibration.
         Calibration ensures the output of the [predict_proba](https://scikit-learn.org/stable/glossary.html#term-predict_proba)
         method can be directly interpreted as a confidence level.
-
-    calib_method : str, default="sigmoid"
-        Which calibration method to use.
         Implemented calibration methods are "sigmoid" and "isotonic".
 
     Returns
@@ -1107,6 +1103,7 @@ def med_dml(
                 Cs=cs,
                 cv=CV_FOLDS,
             ).fit(x[train], t[train])
+        if calib_method in {"sigmoid", "isotonic"}:
             res = CalibratedClassifierCV(res, method=calib_method).fit(
                 x[train], t[train]
             )
@@ -1125,6 +1122,7 @@ def med_dml(
                 Cs=cs,
                 cv=CV_FOLDS,
             ).fit(xm[train], t[train])
+        if calib_method in {"sigmoid", "isotonic"}:
             res = CalibratedClassifierCV(res, method=calib_method).fit(
                 xm[train], t[train]
             )

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -935,7 +935,7 @@ def medDML(y, t, m, x, trim=0.05, order=1):
     return list(raw_res_R[0, :5]) + [ntrimmed]
 
 
-def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True):
+def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True, alpha=10**-4):
     """
     Python implementation of Double Machine Learning procedure, as described in :
     Helmut Farbmacher and others, Causal mediation analysis with double machine learning,
@@ -960,6 +960,8 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True):
         Trimming treshold for discarding observations with extreme probability.
     normalized : boolean, default=True
         Normalizes the inverse probability-based weights.
+    alpha : float, default=10**-4
+        Lasso penalization for conditinal means estimation.
 
     Returns
     -------
@@ -1052,7 +1054,7 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True):
         ptmx[i] = res.predict_proba(xm[test])[:, 1]
 
         # predict E[Y|T=1,M,X]
-        res = Lasso(alpha=0.1).fit(xm[train_mean1], y[train_mean1])
+        res = Lasso(alpha).fit(xm[train_mean1], y[train_mean1])
         mut1mx[i] = res.predict(xm[test])
         mut1mx_nested[i] = res.predict(xm[train_nested])
 
@@ -1062,23 +1064,23 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True):
         mut0mx_nested[i] = res.predict(xm[train_nested])
 
         # predict E[E[Y|T=1,M,X]|T=0,X]
-        res = Lasso(alpha=0.01).fit(
+        res = Lasso(alpha).fit(
             x[train_nested0], mut1mx_nested[i][t[train_nested] == 0]
         )
         wt0x[i] = res.predict(x[test])
 
         # predict E[E[Y|T=0,M,X]|T=1,X]
-        res = Lasso(alpha=0.001).fit(
+        res = Lasso(alpha).fit(
             x[train_nested1], mut0mx_nested[i][t[train_nested] == 1]
         )
         wt1x[i] = res.predict(x[test])
 
         # predict E[Y|T=1,X]
-        res = Lasso(alpha=0.0005).fit(x[train1], y[train1])
+        res = Lasso(alpha).fit(x[train1], y[train1])
         mut1x[i] = res.predict(x[test])
 
         # predict E[Y|T=0,X]
-        res = Lasso(alpha=0.05).fit(x[train0], y[train0])
+        res = Lasso(alpha).fit(x[train0], y[train0])
         mut0x[i] = res.predict(x[test])
 
         # trimming

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -955,15 +955,13 @@ def med_dml(
     Parameters
     ----------
     x : array-like, shape (n_samples, n_features_covariates)
-        Covariates value for each unit
-        Can be multidimensional or continuous
+        Covariates value for each unit, multidimensional or continuous.
     t : array-like, shape (n_samples)
-        Treatment value for each unit
+        Treatment value for each unit.
     m : array-like, shape (n_samples, n_features_mediator)
-        Mediator value for each unit
-        Can be multidimensional or continuous
+        Mediator value for each unit, multidimensional or continuous.
     y : array-like, shape (n_samples)
-        Outcome value for each unit
+        Outcome value for each unit.
     crossfit : int, default=0
         Number of folds for cross-fitting.
     trim : float, default=0.05
@@ -979,20 +977,24 @@ def med_dml(
 
     Returns
     -------
-    tuple
-        A tuple of estimated effects :
-        (total effect,
-        direct effect on the exposed,
-        direct effect on the unexposed,
-        indirect effect on the exposed,
-        indirect effect on the unexposed,
-        number of discarded samples)
+    total : float
+        Average total effect.
+    direct1 : float
+        Direct effect on the exposed.
+    direct0 : float
+        Direct effect on the unexposed,
+    indirect1 : float 
+        Indirect effect on the exposed.
+    indirect0 : float
+        Indirect effect on the unexposed.
+    n_discarded : int
+        Number of discarded samples due to trimming.
 
     Raises
     ------
     ValueError
-        If t or y are multidimensional.
-        If x, t, m, or y don't have the same length.
+        - If t or y are multidimensional.
+        - If x, t, m, or y don't have the same length.
     """
     # check format
     if len(y) != len(y.ravel()):

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -935,7 +935,7 @@ def medDML(y, t, m, x, trim=0.05, order=1):
     return list(raw_res_R[0, :5]) + [ntrimmed]
 
 
-def med_dml(x, m, t, y, k=4, trim=0.05, normalized=True):
+def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True):
     """Python implementation of Double Machine Learning procedure, as described in :
     Helmut Farbmacher and others, Causal mediation analysis with double machine learning,
     The Econometrics Journal, Volume 25, Issue 2, May 2022, Pages 277–300,

--- a/src/benchmark_mediation.py
+++ b/src/benchmark_mediation.py
@@ -953,12 +953,12 @@ def med_dml(x, t, m, y, k=4, trim=0.05, normalized=True):
         Can be multidimensional or continuous
     y : array-like, shape (n_samples)
         Outcome value for each unit
-    k : int
-        Number of folds for crossfitting. Default is 4.
-    trim : double
-        Trimming treshold for discarding observations with extreme probability. Default is 0.05.
-    normalized : boolean
-        Normalizes the inverse probability-based weights. Default is True.
+    k : int, default=4
+        Number of folds for crossfitting.
+    trim : double, default=0.05
+        Trimming treshold for discarding observations with extreme probability.
+    normalized : boolean, default=True
+        Normalizes the inverse probability-based weights.
 
     Returns
     -------

--- a/src/get_estimation.py
+++ b/src/get_estimation.py
@@ -677,8 +677,16 @@ def get_estimation(x, t, m, y, estimator, config):
     elif estimator == "DML_huber":
         if config > 0:
             effects = medDML(y, t, m, x, trim=0.0, order=1)
-    elif estimator == "med_dml":
+    elif estimator == "med_dml_noreg":
+        effects = med_dml(x, t, m, y, trim=0, regularization=False)
+    elif estimator == "med_dml_reg":
         effects = med_dml(x, t, m, y, trim=0)
+    elif estimator == "med_dml_reg_fixed_seed":
+        effects = med_dml(x, t, m, y, trim=0, random_state=321)
+    elif estimator == "med_dml_noreg_cf":
+        effects = med_dml(x, t, m, y, trim=0, crossfit=4, regularization=False)
+    elif estimator == "med_dml_reg_cf":
+        effects = med_dml(x, t, m, y, trim=0, crossfit=4)
     elif estimator == "G_estimator":
         if config in (0, 1, 2):
             effects = g_estimator(y, t, m, x)

--- a/src/get_estimation.py
+++ b/src/get_estimation.py
@@ -677,6 +677,8 @@ def get_estimation(x, t, m, y, estimator, config):
     elif estimator == "DML_huber":
         if config > 0:
             effects = medDML(y, t, m, x, trim=0.0, order=1)
+    elif estimator == "med_dml":
+        effects = med_dml(x, t, m, y, trim=0)
     elif estimator == "G_estimator":
         if config in (0, 1, 2):
             effects = g_estimator(y, t, m, x)

--- a/tests/estimation/test_get_estimation.py
+++ b/tests/estimation/test_get_estimation.py
@@ -93,7 +93,7 @@ TOLERANCE_DICT = {
     "multiply_robust_forest_calibration": LARGE_TOLERANCE,
     "simulation_based": LARGE_TOLERANCE,
     "DML_huber": INFINITE_TOLERANCE,
-    "med_dml": INFINITE_TOLERANCE,
+    "med_dml_reg_fixed_seed": INFINITE_TOLERANCE,
     "G_estimator": SMALL_TOLERANCE,
     "huber_ipw_noreg_cf": INFINITE_TOLERANCE,
     "huber_ipw_reg_cf": INFINITE_TOLERANCE,
@@ -112,8 +112,6 @@ TOLERANCE_DICT = {
     "multiply_robust_forest_calibration_cf": MEDIUM_TOLERANCE,
 }
 
-TOLERANCE_DICT = {
-    "med_dml": MEDIUM_TOLERANCE,}
 
 PARAMETER_NAME = [
     "n",

--- a/tests/estimation/test_get_estimation.py
+++ b/tests/estimation/test_get_estimation.py
@@ -93,6 +93,7 @@ TOLERANCE_DICT = {
     "multiply_robust_forest_calibration": LARGE_TOLERANCE,
     "simulation_based": LARGE_TOLERANCE,
     "DML_huber": INFINITE_TOLERANCE,
+    "med_dml": INFINITE_TOLERANCE,
     "G_estimator": SMALL_TOLERANCE,
     "huber_ipw_noreg_cf": INFINITE_TOLERANCE,
     "huber_ipw_reg_cf": INFINITE_TOLERANCE,
@@ -111,6 +112,8 @@ TOLERANCE_DICT = {
     "multiply_robust_forest_calibration_cf": MEDIUM_TOLERANCE,
 }
 
+TOLERANCE_DICT = {
+    "med_dml": MEDIUM_TOLERANCE,}
 
 PARAMETER_NAME = [
     "n",


### PR DESCRIPTION
A Python implementation of the already existing R function medDML, which provides similar results.
If you wish to compare with R, here the code :

```
import numpy as np
from numpy.random import default_rng
from med_bench.src.get_simulated_data import simulate_data
from med_bench.src.benchmark_mediation import medDML, med_dml

data = simulate_data(
    1000, default_rng(3), False, False, 2, 1, 7, "binary", 0.5, 0.5, 0.5, 0.5
)
x = data[0]
t = data[1]
m = data[2]
y = data[3]
effects = np.array(data[4:9])
proba = np.array(data[9:11])

res_r = medDML(y.ravel(), t.ravel(), m, x)
res_python = med_dml(x, t, m, y)
print(res_r)
print(res_python)

error_r = abs((res_r[0:5] - effects) / effects)
error_python = abs((res_python[0:5] - effects) / effects)
print(error_r)
print(error_python)
```

```
print(res_r)
[1.3048670521145547, 1.226514998320843, 1.1352313574251864, 0.16963569468936823, 0.07835205379371174, 71.0]
print(res_python)
[1.283569626175278, 1.1560215941529228, 1.220204946283059, 0.06336467989221894, 0.1275480320223553, 72]
print(true_effects)
[1.325, 1.2  , 1.2  , 0.125, 0.125]
```

Note : Often one of the two pairs (direct0,indirect1) and (direct1,indirect0) is biased, either in R or Python
Note : I'm not sure which alpha should I take for Lasso estimations, I've chosen them arbitrarily