### PR TITLE
[ENH] parallelize `cross_fit_estimate` with joblib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setuptools.setup(
         "pytest",
         "sphinx",
         "pydata_sphinx_theme",
-        "sphinx-gallery"
+        "sphinx-gallery",
+        "tqdm"
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/src/med_bench/estimation/base.py
+++ b/src/med_bench/estimation/base.py
@@ -7,6 +7,8 @@ from med_bench.utils.decorators import fitted
 from med_bench.utils.density import GaussianDensityEstimation
 from sklearn.cluster import KMeans
 from sklearn.preprocessing import LabelEncoder
+from joblib import Parallel, delayed
+from tqdm import tqdm
 
 
 class Estimator:
@@ -128,7 +130,7 @@ class Estimator:
         }
         return causal_effects
 
-    def cross_fit_estimate(self, t, m, x, y, n_splits=1):
+    def cross_fit_estimate(self, t, m, x, y, n_splits=1, n_jobs=1):
         """Estimate causal effect on data with cross-fitting
 
         Parameters
@@ -146,34 +148,36 @@ class Estimator:
         y       array-like, shape (n_samples)
                 outcome value for each unit, continuous
 
+        n_splits: int
+                number of splits for cross-fitting
+
+        n_jobs: int
+                number of parallel jobs for cross-fitting. Parallelization is done over
+                splits.
         """
 
         # Initialize KFold for sample splitting
         kfold = KFold(n_splits=n_splits)
 
-        n = t.shape[0]
-
-        # Create placeholders for cross-fitted predictions
-        y0m0 = np.zeros(n)
-        y0m1 = np.zeros(n)
-        y1m0 = np.zeros(n)
-        y1m1 = np.zeros(n)
-
-        # Cross-Fitting
-        for train_idx, test_idx in kfold.split(x):
-
+        def _joblib_fit_pointwise_estimate(train_idx, test_idx):
             # Train nuisance models on one split
             self.fit(t[train_idx], m[train_idx], x[train_idx], y[train_idx])
 
             # Predict for the other split
-            y0m0_fold, y0m1_fold, y1m0_fold, y1m1_fold = self._pointwise_estimate(
+            return self._pointwise_estimate(
                 t[test_idx], m[test_idx], x[test_idx], y[test_idx]
             )
 
-            y0m0[test_idx] = y0m0_fold
-            y0m1[test_idx] = y0m1_fold
-            y1m0[test_idx] = y1m0_fold
-            y1m1[test_idx] = y1m1_fold
+        # Cross-Fitting
+        results = Parallel(n_jobs=n_jobs)(
+            delayed(_joblib_fit_pointwise_estimate)(train_idx, test_idx)
+            for train_idx, test_idx in tqdm(kfold.split(x), total=n_splits)
+        )
+        y0m0, y0m1, y1m0, y1m1 = zip(*results)
+        y0m0 = np.concatenate(y0m0)
+        y0m1 = np.concatenate(y0m1)
+        y1m0 = np.concatenate(y1m0)
+        y1m1 = np.concatenate(y1m1)
 
         # effects computing
         total = np.mean(y1m1 - y0m0)

--- a/src/tests/estimation/test_get_estimation.py
+++ b/src/tests/estimation/test_get_estimation.py
@@ -28,6 +28,8 @@ from med_bench.utils.constants import (
     TOLERANCE_FACTOR_DICT,
     ESTIMATORS,
 )
+from med_bench.estimation.mediation_mr import MultiplyRobust
+from sklearn.linear_model import LogisticRegression, LinearRegression
 
 
 @pytest.fixture(params=CONFIGURATION_NAMES)
@@ -143,4 +145,48 @@ def test_robustness_to_ravel_format(data_simulated, estimator, effects_chap):
         == pytest.approx(
             effects_chap, nan_ok=True
         )  # effects_chap is obtained with data[1].ravel() and data[3].ravel()
+    )
+
+
+def test_cross_fit_estimate(data_simulated):
+    estimator = MultiplyRobust(
+        clip=1e-6,
+        trim=0,
+        prop_ratio="treatment",
+        normalized=True,
+        regressor=LinearRegression(),
+        classifier=LogisticRegression(),
+        integration="implicit",
+    )
+    res = estimator.cross_fit_estimate(
+        t=data_simulated[1],
+        m=data_simulated[2],
+        y=data_simulated[3],
+        x=data_simulated[0],
+        n_splits=3,
+    )
+    res_n_jobs = estimator.cross_fit_estimate(
+        t=data_simulated[1],
+        m=data_simulated[2],
+        y=data_simulated[3],
+        x=data_simulated[0],
+        n_splits=3,
+        n_jobs=2,
+    )
+
+    tol = 1e-9
+    assert abs(res["total_effect"] - res_n_jobs["total_effect"]) <= tol
+    assert (
+        abs(res["direct_effect_treated"] - res_n_jobs["direct_effect_treated"]) <= tol
+    )
+    assert (
+        abs(res["direct_effect_control"] - res_n_jobs["direct_effect_control"]) <= tol
+    )
+    assert (
+        abs(res["indirect_effect_treated"] - res_n_jobs["indirect_effect_treated"])
+        <= tol
+    )
+    assert (
+        abs(res["indirect_effect_control"] - res_n_jobs["indirect_effect_control"])
+        <= tol
     )


### PR DESCRIPTION
To solve #110, I suggest parallelizing the CV loop with joblib. It saves quite a bit of time on examples I've tried locally. 
I also added a sanity check to ensure that parallelization with n_jobs > 1 does not change the results. 

Also, I had some problems running the test suite and had to move `get_estimation_results` to `src/med_bench/estimation` to resolve the problem. 